### PR TITLE
Switch iams config to use legacy auth endpoints

### DIFF
--- a/configurations/build.iams-staging.yaml
+++ b/configurations/build.iams-staging.yaml
@@ -9,9 +9,9 @@ targets:
           # Authentication options
           authByEmailEnabled: true
           authByPhoneEnabled: false
-          useLegacyAuthDatasource: false
-          authServiceAppClientId: 2mapp17u8ep4pi30kikumlcpuv
-          authServiceUserPoolId: eu-west-1_iOJbwm0YC
+          useLegacyAuthDatasource: true
+          authServiceAppClientId: null
+          authServiceUserPoolId: null
           externalProfileDataEnabled: false
 
           # Basic features

--- a/configurations/build.iams.yaml
+++ b/configurations/build.iams.yaml
@@ -9,9 +9,9 @@ targets:
           # Authentication options
           authByEmailEnabled: true
           authByPhoneEnabled: false
-          useLegacyAuthDatasource: false
-          authServiceAppClientId: 312jbvheh0cknir4n67uv9f6er
-          authServiceUserPoolId: eu-west-1_R5rlroNro
+          useLegacyAuthDatasource: true
+          authServiceAppClientId: null
+          authServiceUserPoolId: null
           externalProfileDataEnabled: false
 
           # Basic features


### PR DESCRIPTION
## Why ?
Cognito is not bringing any value and has been removed in the backends


## Changes
- Switch to use legacy auth endpoints for IAMS configuration

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] ChangeLog updated

